### PR TITLE
Small visual tweaks, mostly for Dark Reader compat

### DIFF
--- a/docs/clojurelog.css
+++ b/docs/clojurelog.css
@@ -55,7 +55,7 @@ table {
 .m {
   width: 170px;
   background-color: darkorange;
-  color:brown;
+  color: lightyellow;
   text-align: center;
   vertical-align: middle;
   border-radius: 0px;

--- a/docs/index.html
+++ b/docs/index.html
@@ -279,12 +279,12 @@
         </TR>
 
         <TR>
-          <TD>UI console</TD>
+          <TD>GUI console</TD>
           <TD class="n">N</TD>
           <TD class="n">N</TD>
           <TD class="n">N</TD>
           <TD class="n">N</TD>
-          <TD class="y">Y (via `crux-http-server` routes)</TD>
+          <TD class="y">Y</TD>
         </TR>
 
         <TR>
@@ -360,12 +360,7 @@
 		    </TR>
 
         <TR>
-			    <TD>Legend: "N/A" ("not-applicable") means the capability is explicitly a non-goal of the project</TD>
-			    <TD><BR></TD>
-			    <TD><BR></TD>
-			    <TD><BR></TD>
-			    <TD><BR></TD>
-			    <TD><BR></TD>
+			    <TD colspan="6">Legend: "N/A" ("not applicable") means the capability is explicitly a non-goal of the project</TD>
 		    </TR>
 
         <TR>
@@ -383,7 +378,7 @@
 
     <div id="goodbye">
       <p>This matrix was originally created by the Crux team but seeks to avoid bias.</p>
-      Thank you to all the contributors to these exciting projects and to everyone who has provided feedback and input to this matrix.
+      <p>Thank you to all the contributors to these exciting projects and to everyone who has provided feedback and input to this matrix.</p>
       <a href="https://github.com/clojurelog/clojurelog.github.io">
         <img src="https://opencrux.com/_/images/github.svg" />
         <img src="https://opencrux.com/_/images/github-dark.svg" />


### PR DESCRIPTION
- removed qualifier about Crux GUI
- fixed alignment of Legend
- fixed alignment of GitHub logo
- TODO: make "Capabilities" column explanation text tooltip or on-click