### PR TITLE
HTML/CSS changes to make comparison table header sticky

### DIFF
--- a/docs/clojurelog.css
+++ b/docs/clojurelog.css
@@ -16,6 +16,12 @@ table {
   width: 68%;
 }
 
+table > tbody > tr#sticky-header {
+  background-color: #fff;
+  position: sticky;
+  top: 0;
+}
+
 #title-wrapper {
   width: 100%;
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -69,7 +69,7 @@
 
     <TABLE FRAME=VOID CELLSPACING=0 COLS=6 RULES=NONE BORDER=0 >
       <TBODY>
-        <TR>
+        <TR id="sticky-header">
           <TD><b>Capabilities</b></TD>
           <TD class="t"><a href="https://github.com/tonsky/datascript">DataScript</a></TD>
           <TD class="t"><a href="https://github.com/juji-io/datalevin">Datalevin</a></TD>


### PR DESCRIPTION
PR adds stickiness to the header of comparison table.

![sticky-header-datalog](https://user-images.githubusercontent.com/42350899/200561462-5a2869ec-04c1-4b33-9e95-4695ee93117d.gif)
